### PR TITLE
Chore: Fix pandas testing dependency by downgrading to pandas 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ release = [
 ]
 test = [
   "dask",
-  "pandas",
+  "pandas<2.1",
   "pytest<8",
   "pytest-cov<5",
   "pytest-mock<4",


### PR DESCRIPTION
Need to downgrade pandas, which is used for testing.

```python
ImportError: cannot import name 'makeTimeDataFrame' from 'pandas._testing'
```
