### PR TITLE
Revert "Bump github/codeql-action from 2 to 3"

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,8 +33,17 @@ jobs:
         sqla-version: ['<1.4', '<1.5', '<2.1']
 
     steps:
-      - name: Checkout
+      - name: Acquire sources
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: x64
+          cache: 'pip'
+          cache-dependency-path:
+            pyproject.toml
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yml
@@ -52,6 +52,6 @@ jobs:
           pip install "sqlalchemy${{ matrix.sqla-version }}" --upgrade --pre
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v2
         with:
           category: "/language:${{ matrix.language }}/sqla-version:${{ matrix.sqla-version }}"


### PR DESCRIPTION
## About
This reverts commit 2cc91474c179418d34fcd72ad61df8f88f9e01c6.
CodeQL checks started failing [^1], maybe because of GH-2?

[^1]: https://github.com/crate-workbench/sqlalchemy-cratedb/actions/runs/7615862437/job/20828562756?pr=30
