### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
           flags: main


### PR DESCRIPTION
## About

`codecov-action@v4` has issues, it apparently does not upload without token any longer.

This reverts commit 45735bd1a7eb0aa508d9f5b830424a3e880d429a.

## References

- GH-36
