### PR TITLE
Dependencies: Use `dask[dataframe]`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+- Dependencies: Use `dask[dataframe]`
+
 
 ## 2023/09/29 0.34.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ release = [
   "twine<6",
 ]
 test = [
-  "dask",
+  "dask[dataframe]",
   "pandas<2.3",
   "pueblo>=0.0.7",
   "pytest<9",


### PR DESCRIPTION
## Problem
```
ImportError: Dask dataframe requirements are not installed.
```

-- https://github.com/crate-workbench/sqlalchemy-cratedb/actions/runs/8424937102/job/23069945255?pr=50#step:6:537

## References
- https://github.com/crate-workbench/cratedb-toolkit/pull/128
- https://github.com/crate-workbench/sqlalchemy-cratedb/pull/49
- https://github.com/crate-workbench/sqlalchemy-cratedb/pull/50
