### PR TITLE
CI: Update to codecov-action@v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,10 +89,12 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./coverage.xml
           flags: main
           env_vars: OS,PYTHON
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true


### PR DESCRIPTION
## Codecov Client Update
> Tokenless uploading is unsupported. However, PRs made from forks to
> the upstream public repos will support tokenless (e.g. contributors to
> OS projects do not need the upstream repo's Codecov token). This doc
> shows instructions on how to add the Codecov token.
>
> -- https://docs.codecov.com/docs/adding-the-codecov-token#github-actions

## References
- https://github.com/crate-workbench/mlflow-cratedb/pull/103
- https://github.com/crate-workbench/cratedb-toolkit/pull/116
