### PR TITLE
Chore: Fix package entrypoint and module imports after migration from crate-python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-          cache-dependency-path: 'setup.py'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Build package
         run: |
-          python -m pip install twine wheel
-          python setup.py sdist bdist_wheel
-          twine check dist/*.tar.gz
+          python -m pip install build twine
+          python -m build
+          twine check dist/{*.tar.gz,*.whl}
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 ## Unreleased
 
 - Dependencies: Use `dask[dataframe]`
+- Maintenance release after splitting packages `crate-python` vs.
+  `sqlalchemy-cratedb`
 
 
 ## 2023/09/29 0.34.0

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,7 +28,7 @@ After that is done, you can import the library, like so:
 
 .. code-block:: python
 
-    >>> from sqlalchemy_cratedb import CrateDialect
+    >>> from sqlalchemy_cratedb import dialect
 
 Set up as a dependency
 ======================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ documentation = "https://github.com/crate-workbench/sqlalchemy-cratedb"
 homepage = "https://github.com/crate-workbench/sqlalchemy-cratedb"
 repository = "https://github.com/crate-workbench/sqlalchemy-cratedb"
 [project.entry-points."sqlalchemy.dialects"]
-crate = "sqlalchemy_cratedb:CrateDialect"
+crate = "sqlalchemy_cratedb:dialect"
 
 [tool.black]
 line-length = 100

--- a/src/sqlalchemy_cratedb/__init__.py
+++ b/src/sqlalchemy_cratedb/__init__.py
@@ -20,7 +20,7 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 from .compat.api13 import monkeypatch_add_exec_driver_sql
-from .dialect import CrateDialect
+from .dialect import dialect
 from .predicate import match
 from .sa_version import SA_1_4, SA_2_0, SA_VERSION
 from .support import insert_bulk
@@ -50,7 +50,7 @@ if SA_VERSION < SA_1_4:
 
 
 __all__ = [
-    CrateDialect,
+    dialect,
     Geopoint,
     Geoshape,
     ObjectArray,

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -367,3 +367,6 @@ class CrateDialect(default.DefaultDialect):
 class DateTrunc(functions.GenericFunction):
     name = "date_trunc"
     type = sqltypes.TIMESTAMP
+
+
+dialect = CrateDialect

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy_cratedb.compat.api13 import monkeypatch_amend_select_sa14, monkeypatch_add_connectionfairy_driver_connection
 from sqlalchemy_cratedb.sa_version import SA_1_4, SA_VERSION
-from crate.client.test_util import ParametrizedTestCase
+from .util import ParametrizedTestCase
 
 # `sql.select()` of SQLAlchemy 1.3 uses old calling semantics,
 # but the test cases already need the modern ones.

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -38,7 +38,7 @@ except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
 from sqlalchemy_cratedb import SA_VERSION, SA_1_4, SA_2_0, ObjectType
-from crate.client.test_util import ParametrizedTestCase
+from .util import ParametrizedTestCase
 
 
 


### PR DESCRIPTION
## About
Another few maintenance adjustments in the spirit of GH-66.

## Details
Those are aftermath fixes, and intended to be included into an initial release of this package, before adding any other features.

## More
Along the lines, 5d274c3358a also updates the CI/GHA job for staging release packages to PyPI.