### PR TITLE
Dependencies: Use `crate==1.0.0dev0`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Dependencies: Use `crate==1.0.0dev0`
 
 ## 2024/06/11 0.36.0
 - Dependencies: Use `dask[dataframe]`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dynamic = [
 ]
 dependencies = [
   'backports.zoneinfo<1; python_version < "3.9"',
-  "crate",
+  "crate==1.0.0dev0",
   "geojson<4,>=2.5",
   'importlib-resources; python_version < "3.9"',
   "sqlalchemy<2.1,>=1",


### PR DESCRIPTION
Better pinning it here instead of polluting downstream projects. This version of `crate-python` has been stripped off the SQLAlchemy code, because it lives here now.