### PR TITLE
Chore: Fix "Importing value of mutable attribute" in test case

### DIFF
--- a/tests/insert_from_select_test.py
+++ b/tests/insert_from_select_test.py
@@ -23,7 +23,6 @@ from unittest import TestCase, skipIf
 from unittest.mock import patch, MagicMock
 
 import sqlalchemy as sa
-from sqlalchemy import select, insert
 from sqlalchemy.orm import Session
 
 from sqlalchemy_cratedb import SA_VERSION, SA_1_4
@@ -78,8 +77,8 @@ class SqlAlchemyInsertFromSelectTest(TestCase):
         self.session.add(char)
         self.session.commit()
 
-        sel = select(self.character.name, self.character.age).where(self.character.status == "Archived")
-        ins = insert(self.character_archived).from_select(['name', 'age'], sel)
+        sel = sa.select(self.character.name, self.character.age).where(self.character.status == "Archived")
+        ins = sa.insert(self.character_archived).from_select(['name', 'age'], sel)
         self.session.execute(ins)
         self.session.commit()
         self.assertSQL(


### PR DESCRIPTION
## About
GitHub/CodeQL code quality security scanning raised an admonition, `py/import-of-mutable-attribute`, at this spot:

https://github.com/crate-workbench/sqlalchemy-cratedb/blob/3c58403a4c8ffa18601190dac80ba15b675342ae/tests/insert_from_select_test.py#L26-L26

> Importing the value of 'select' from means that any change made to will be not be observed locally. 

## References
- https://github.com/crate-workbench/sqlalchemy-cratedb/security/code-scanning/89