### PR TITLE
Documentation: Add/reactivate documentation as `sqlalchemy-cratedb`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-          cache-dependency-path: 'setup.py'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Build docs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 *.pyc
 .coverage
 coverage.xml
-dist/
+/build
+/dist

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Added/reactivated documentation as `sqlalchemy-cratedb`
 
 ## 2024/06/13 0.37.0
 - Added support for CrateDB's [FLOAT_VECTOR] data type and its accompanying

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -167,7 +167,7 @@ Otherwise, SQLAlchemy will complain like:
     specificity
 
 
-[CrateDB system columns]: https://crate.io/docs/crate/reference/en/4.8/general/ddl/system-columns.html
+[CrateDB system columns]: https://cratedb.com/docs/crate/reference/en/4.8/general/ddl/system-columns.html
 [SQLAlchemy literal_column]: https://docs.sqlalchemy.org/en/14/core/sqlelement.html#sqlalchemy.sql.expression.literal_column
 [What’s New in SQLAlchemy 1.4?]: https://docs.sqlalchemy.org/en/14/changelog/migration_14.html
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ pip install --upgrade sqlalchemy-cratedb
 
 ## Documentation and help
 
-- [CrateDB Python Client documentation](https://crate.io/docs/python/)
-- [CrateDB reference documentation](https://crate.io/docs/reference/)
+- [SQLAlchemy dialect for CrateDB](https://cratedb.com/docs/sqlalchemy-cratedb/)
+- [CrateDB Python Client documentation](https://cratedb.com/docs/python/)
+- [CrateDB reference documentation](https://cratedb.com/docs/reference/)
 - [Developer documentation](DEVELOP.md)
 - [Contributing](CONTRIBUTING.md)
-- Other [support channels](https://crate.io/support/)
+- Other [support channels](https://cratedb.com/support)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/crate-workbench/sqlalchemy-cratedb/actions/workflows/tests.yml/badge.svg)](https://github.com/crate-workbench/sqlalchemy-cratedb/actions/workflows/tests.yml)
 [![Coverage](https://codecov.io/gh/crate-workbench/sqlalchemy-cratedb/branch/main/graph/badge.svg)](https://app.codecov.io/gh/crate-workbench/sqlalchemy-cratedb)
-[![Build status (documentation)](https://readthedocs.org/projects/sqlalchemy-cratedb/badge/)](https://crate.io/docs/python/)
+[![Build status (documentation)](https://readthedocs.org/projects/sqlalchemy-cratedb/badge/)](https://cratedb.com/docs/sqlalchemy-cratedb/)
 [![PyPI Version](https://img.shields.io/pypi/v/sqlalchemy-cratedb.svg)](https://pypi.org/project/sqlalchemy-cratedb/)
 [![Python Version](https://img.shields.io/pypi/pyversions/sqlalchemy-cratedb.svg)](https://pypi.org/project/sqlalchemy-cratedb/)
 [![PyPI Downloads](https://pepy.tech/badge/sqlalchemy-cratedb/month)](https://pepy.tech/project/sqlalchemy-cratedb/)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Bootstrap sandbox environment for crate-python
+# Bootstrap sandbox environment for sqlalchemy-cratedb
 #
 # - Create a Python virtualenv
 # - Install all dependency packages and modules

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-# Licensed to Crate (https://crate.io) under one or more contributor license
+# Licensed to Crate (https://cratedb.com) under one or more contributor license
 # agreements.  See the NOTICE file distributed with this work for additional
 # information regarding copyright ownership.  Crate licenses this file to you
 # under the Apache License, Version 2.0 (the "License"); you may not use this

--- a/docs/_extra/robots.txt
+++ b/docs/_extra/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow: /
 
-Sitemap: https://crate.io/docs/python/en/latest/site.xml
+Sitemap: https://cratedb.com/docs/sqlalchemy-cratedb/site.xml

--- a/docs/advanced-querying.rst
+++ b/docs/advanced-querying.rst
@@ -205,7 +205,7 @@ Using the ``group_by`` clause is similar:
 
 In SQLAlchemy, the ``insert().from_select()`` function returns a new ``Insert``
 construct, which represents an ``INSERT...FROM SELECT`` statement. This
-functionality is supported by the CrateDB client library. Here is an example
+functionality is supported by the SQLAlchemy CrateDB dialect. Here is an example
 that uses ``insert().from_select()``.
 
 First, let's define and create the tables:

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.1"
+  "message": "2.1.2"
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,4 @@
-from crate.theme.rtd.conf.python import *
-
-
-if "sphinx.ext.intersphinx" not in extensions:
-    extensions += ["sphinx.ext.intersphinx"]
+from crate.theme.rtd.conf.sqlalchemy_cratedb import *
 
 
 if "intersphinx_mapping" not in globals():
@@ -12,7 +8,6 @@ if "intersphinx_mapping" not in globals():
 intersphinx_mapping.update({
     'py': ('https://docs.python.org/3/', None),
     'sa': ('https://docs.sqlalchemy.org/en/20/', None),
-    'urllib3': ('https://urllib3.readthedocs.io/en/1.26.13/', None),
     'dask': ('https://docs.dask.org/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/docs/', None),
     })

--- a/docs/data-types.rst
+++ b/docs/data-types.rst
@@ -57,31 +57,31 @@ CrateDB           SQLAlchemy
 ================= =========================================
 
 
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Boolean
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.SmallInteger
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.SmallInteger
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Integer
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.NUMERIC
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Float
 __ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#float-vector
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.DECIMAL
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#dates-and-times
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#dates-and-times
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.TIMESTAMP
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.String
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#array
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#array
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.ARRAY
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#object
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#array
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-point
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-shape
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#object
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#array
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-point
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-shape
 
 
 .. _Unix time: https://en.wikipedia.org/wiki/Unix_time

--- a/docs/dataframe.rst
+++ b/docs/dataframe.rst
@@ -236,7 +236,7 @@ pandas implementation introduced in the previous section.
 
 .. _batching: https://en.wikipedia.org/wiki/Batch_processing#Common_batch_processing_usage
 .. _chunking: https://en.wikipedia.org/wiki/Chunking_(computing)
-.. _CrateDB bulk operations: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
+.. _CrateDB bulk operations: https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
 .. _Dask: https://en.wikipedia.org/wiki/Dask_(software)
 .. _DataFrame computing: https://realpython.com/pandas-dataframe/
 .. _ETL: https://en.wikipedia.org/wiki/Extract,_transform,_load

--- a/docs/index-all.rst
+++ b/docs/index-all.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+.. _index-all:
+
+#######################################
+CrateDB SQLAlchemy dialect -- all pages
+#######################################
+
+
+.. rubric:: Table of contents
+
+.. toctree::
+    :maxdepth: 2
+
+    getting-started
+    crud
+    working-with-types
+    advanced-querying
+    inspection-reflection
+    dataframe

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -206,7 +206,7 @@ The project is licensed under the terms of the Apache 2.0 license, like
 
 
 .. _Apache Superset: https://github.com/apache/superset
-.. _CrateDB: https://crate.io/products/cratedb
+.. _CrateDB: https://cratedb.com/database
 .. _CrateDB Cloud: https://console.cratedb.cloud/
 .. _CrateDB source: https://github.com/crate/crate
 .. _Create an issue: https://github.com/crate-workbench/sqlalchemy-cratedb/issues

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,12 +11,13 @@ SQLAlchemy dialect for CrateDB
     :depth: 1
 
 
-************
-Introduction
-************
+*****
+About
+*****
 
 The :ref:`CrateDB dialect <using-sqlalchemy>` for `SQLAlchemy`_ provides adapters
 for `CrateDB`_ and SQLAlchemy. The supported versions are 1.3, 1.4, and 2.0.
+The package is available from `PyPI`_ at `sqlalchemy-cratedb`_.
 
 The connector can be used to connect to both `CrateDB`_ and `CrateDB
 Cloud`_, and is verified to work on Linux, macOS, and Windows. It is used by
@@ -25,29 +26,40 @@ CrateDB from the Python ecosystem. It is verified to work with CPython, but
 it has also been tested successfully with `PyPy`_.
 
 
-*************
-Documentation
-*************
+************
+Introduction
+************
 
 Please consult the `SQLAlchemy tutorial`_, and the general `SQLAlchemy
 documentation`_.
-For more detailed information about how to install the client driver, how to
+For more detailed information about how to install the dialect package, how to
 connect to a CrateDB cluster, and how to run queries, consult the resources
 referenced below.
+
+
+************
+Installation
+************
+
+Install package from PyPI.
+
+.. code-block:: shell
+
+    pip install --upgrade sqlalchemy-cratedb
+
+More installation details can be found over here.
 
 .. toctree::
     :titlesonly:
 
     install
 
-SQLAlchemy
-==========
 
-Install package from PyPI.
+.. _features:
 
-.. code-block:: shell
-
-    pip install sqlalchemy-cratedb
+********
+Features
+********
 
 The CrateDB dialect for `SQLAlchemy`_ offers convenient ORM access and supports
 CrateDB's container data types ``OBJECT`` and ``ARRAY``, its vector data type
@@ -59,23 +71,20 @@ kinds of `GeoJSON geometry objects`_.
 
     overview
 
-Install package from PyPI with DB API and SQLAlchemy support.
 
-.. code-block:: shell
+.. _synopsis:
 
-    pip install sqlalchemy-cratedb pandas
+Synopsis
+========
 
 Connect to CrateDB instance running on ``localhost``.
 
 .. code-block:: python
 
     # Connect using SQLAlchemy Core.
-    import pkg_resources
     import sqlalchemy as sa
     from pprint import pp
 
-    pkg_resources.require("sqlalchemy>=2.0")
-    
     dburi = "crate://localhost:4200"
     query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"
     
@@ -94,6 +103,10 @@ Connect to `CrateDB Cloud`_.
     engine = sa.create_engine(dburi, echo=True)
 
 Load results into `pandas`_ DataFrame.
+
+.. code-block:: shell
+
+    pip install pandas
 
 .. code-block:: python
 
@@ -114,13 +127,15 @@ Load results into `pandas`_ DataFrame.
 Data types
 ==========
 
-The DB API driver and the SQLAlchemy dialect support :ref:`CrateDB's data types
-<crate-reference:data-types>` to different degrees. For more information,
-please consult the :ref:`data-types` and :ref:`SQLAlchemy extension types
-<using-extension-types>` documentation pages.
+The :ref:`DB API driver <crate-python:index>` and the SQLAlchemy dialect
+support :ref:`CrateDB's data types <crate-reference:data-types>` to different
+degrees.
+For more information, please consult the :ref:`data-types` and :ref:`SQLAlchemy
+extension types <using-extension-types>` documentation pages.
 
 .. toctree::
     :maxdepth: 2
+    :hidden:
 
     data-types
 
@@ -129,8 +144,9 @@ please consult the :ref:`data-types` and :ref:`SQLAlchemy extension types
 .. _by-example:
 .. _sqlalchemy-by-example:
 
+********
 Examples
-========
+********
 
 This section enumerates concise examples demonstrating the
 use of the SQLAlchemy dialect.
@@ -145,15 +161,12 @@ use of the SQLAlchemy dialect.
     inspection-reflection
     dataframe
 
+.. rubric:: See also
 
-See also
---------
 - Executable code examples are maintained within the `cratedb-examples repository`_.
-- The `sample application`_ and the corresponding `sample application
-  documentation`_ demonstrate the use of the driver on behalf of an example
-  "guestbook" application.
-- `Use CrateDB with pandas`_ has corresponding code snippets about how to
-  connect to CrateDB using `pandas`_, and how to load and export data.
+- `Using CrateDB with pandas, Dask, and Polars`_ has corresponding code snippets
+  about how to connect to CrateDB using popular data frame libraries, and how to
+  load and export data.
 - The `Apache Superset`_ and `FIWARE QuantumLeap data historian`_ projects.
 
 
@@ -164,13 +177,13 @@ Project information
 
 Resources
 =========
-- `Source code <https://github.com/crate/crate-python>`_
-- `Documentation <https://crate.io/docs/python/>`_
-- `Python Package Index (PyPI) <https://pypi.org/project/crate/>`_
+- `Source code <https://github.com/crate-workbench/sqlalchemy-cratedb>`_
+- `Documentation <https://github.com/crate-workbench/sqlalchemy-cratedb>`_
+- `Python Package Index (PyPI) <https://pypi.org/project/sqlalchemy-cratedb/>`_
 
 Contributions
 =============
-The CrateDB Python client library is an open source project, and is `managed on
+The SQLAlchemy dialect for CrateDB is an open source project, and is `managed on
 GitHub`_.
 Every kind of contribution, feedback, or patch, is much welcome. `Create an
 issue`_ or submit a patch if you think we should include a new feature, or to
@@ -193,24 +206,23 @@ The project is licensed under the terms of the Apache 2.0 license, like
 
 
 .. _Apache Superset: https://github.com/apache/superset
-.. _Crash CLI: https://crate.io/docs/crate/crash/
 .. _CrateDB: https://crate.io/products/cratedb
 .. _CrateDB Cloud: https://console.cratedb.cloud/
 .. _CrateDB source: https://github.com/crate/crate
-.. _Create an issue: https://github.com/crate/crate-python/issues
-.. _development sandbox: https://github.com/crate/crate-python/blob/master/DEVELOP.rst
+.. _Create an issue: https://github.com/crate-workbench/sqlalchemy-cratedb/issues
+.. _development sandbox: https://github.com/crate-workbench/sqlalchemy-cratedb/blob/main/DEVELOP.md
 .. _cratedb-examples repository: https://github.com/crate/cratedb-examples/tree/main/by-language
 .. _FIWARE QuantumLeap data historian: https://github.com/orchestracities/ngsi-timeseries-api
 .. _GeoJSON: https://geojson.org/
 .. _GeoJSON geometry objects: https://tools.ietf.org/html/rfc7946#section-3.1
-.. _LICENSE: https://github.com/crate/crate-python/blob/master/LICENSE
-.. _managed on GitHub: https://github.com/crate/crate-python
+.. _LICENSE: https://github.com/crate-workbench/sqlalchemy-cratedb/blob/main/LICENSE
+.. _managed on GitHub: https://github.com/crate-workbench/sqlalchemy-cratedb
 .. _pandas: https://pandas.pydata.org/
 .. _PEP 249: https://peps.python.org/pep-0249/
+.. _PyPI: https://pypi.org/
 .. _PyPy: https://www.pypy.org/
-.. _sample application: https://github.com/crate/crate-sample-apps/tree/main/python-flask
-.. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/main/python-flask/documentation.md
 .. _SQLAlchemy: https://www.sqlalchemy.org/
 .. _SQLAlchemy documentation: https://docs.sqlalchemy.org/
 .. _SQLAlchemy tutorial: https://docs.sqlalchemy.org/en/latest/tutorial/
-.. _Use CrateDB with pandas: https://github.com/crate/crate-qa/pull/246
+.. _sqlalchemy-cratedb: https://pypi.org/project/sqlalchemy-cratedb/
+.. _Using CrateDB with pandas, Dask, and Polars: https://github.com/crate/cratedb-examples/tree/main/by-dataframe

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,8 +4,8 @@
 Install
 =======
 
-Learn how to install and get started with the Python client library for
-`CrateDB`_.
+Learn how to install and get started with the SQLAlchemy dialect for
+`CrateDB`_. The package is available from `PyPI`_ at `sqlalchemy-cratedb`_.
 
 .. rubric:: Table of contents
 
@@ -15,12 +15,10 @@ Learn how to install and get started with the Python client library for
 Install
 =======
 
-.. highlight:: sh
-
-The CrateDB Python client is available as package ``sqlalchemy-cratedb`` on `PyPI`_.
-
 To install the most recent driver version, including the SQLAlchemy dialect
-extension, run::
+extension, run:
+
+.. code-block:: shell
 
     pip install --upgrade sqlalchemy-cratedb
 
@@ -42,11 +40,11 @@ and reproducible, achieving `repeatable installations`_.
 Next steps
 ==========
 
-Learn how to :ref:`connect to CrateDB <connect>`.
+Learn how to :ref:`get started <getting-started>`, or how to :ref:`connect to CrateDB <connect>`.
 
 
-.. _sqlalchemy-cratedb: https://pypi.org/project/sqlalchemy-cratedb/
-.. _CrateDB: https://crate.io/products/cratedb/
+.. _CrateDB: https://cratedb.com/database
 .. _many ways: https://packaging.python.org/key_projects/
 .. _PyPI: https://pypi.org/
 .. _repeatable installations: https://pip.pypa.io/en/latest/topics/repeatable-installs/
+.. _sqlalchemy-cratedb: https://pypi.org/project/sqlalchemy-cratedb/

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -18,9 +18,9 @@ Introduction
 `SQLAlchemy`_ is the most popular `Object-Relational Mapping`_ (ORM) library
 for Python.
 
-The CrateDB Python client library provides support for SQLAlchemy. An
-:ref:`SQLAlchemy dialect <sa:dialect_toplevel>` for CrateDB is registered at
-installation time and can be used without further configuration.
+The ``sqlalchemy-cratedb`` package provides the :ref:`SQLAlchemy dialect
+<sa:dialect_toplevel>` for `CrateDB`_. It is registered at
+installation time, and can be used without further configuration.
 
 The CrateDB SQLAlchemy dialect is validated to work with SQLAlchemy versions
 ``1.3``, ``1.4``, and ``2.0``.
@@ -710,6 +710,7 @@ column on the ``Character`` class.
 .. _arguments reference: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
 .. _boost values: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
 .. _count result rows: https://docs.sqlalchemy.org/en/14/orm/tutorial.html#counting
+.. _CrateDB: https://cratedb.com/database
 .. _CrateDB Cloud: https://console.cratedb.cloud/
 .. _Database API: https://www.python.org/dev/peps/pep-0249/
 .. _geojson geometry objects: https://www.rfc-editor.org/rfc/rfc7946#section-3.1

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -707,16 +707,16 @@ the virtual column name as a string (``_score``) instead of using a defined
 column on the ``Character`` class.
 
 
-.. _arguments reference: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
-.. _boost values: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
+.. _arguments reference: https://cratedb.com/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
+.. _boost values: https://cratedb.com/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
 .. _count result rows: https://docs.sqlalchemy.org/en/14/orm/tutorial.html#counting
 .. _CrateDB: https://cratedb.com/database
 .. _CrateDB Cloud: https://console.cratedb.cloud/
 .. _Database API: https://www.python.org/dev/peps/pep-0249/
 .. _geojson geometry objects: https://www.rfc-editor.org/rfc/rfc7946#section-3.1
-.. _match options: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#options
+.. _match options: https://cratedb.com/docs/crate/reference/en/latest/general/dql/fulltext.html#options
 .. _Object-Relational Mapping: https://en.wikipedia.org/wiki/Object-relational_mapping
-.. _score usage: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#usage
+.. _score usage: https://cratedb.com/docs/crate/reference/en/latest/general/dql/fulltext.html#usage
 .. _SQLAlchemy: https://www.sqlalchemy.org/
 .. _SQLAlchemy library: https://www.sqlalchemy.org/library.html
 .. _URL: https://en.wikipedia.org/wiki/Uniform_Resource_Locator

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme==0.32.4dev1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ authors = [
 ]
 requires-python = ">=3.6"
 classifiers = [
-  "Development Status :: 3 - Alpha",
-  "Environment :: Console",
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Plugins",
   "Intended Audience :: Customer Service",
   "Intended Audience :: Developers",
   "Intended Audience :: Education",

--- a/src/sqlalchemy_cratedb/compat/api13.py
+++ b/src/sqlalchemy_cratedb/compat/api13.py
@@ -123,8 +123,8 @@ def monkeypatch_amend_select_sa14():
     Make SA13's `sql.select()` transparently accept calling semantics of SA14
     and SA20, by swapping in the newer variant of `select_sa14()`.
 
-    This supports the test suite of `crate-python`, because it already uses the
-    modern calling semantics.
+    This supports the test suite, because it already uses the modern calling
+    semantics.
     """
     import sqlalchemy
 

--- a/src/sqlalchemy_cratedb/support.py
+++ b/src/sqlalchemy_cratedb/support.py
@@ -42,7 +42,7 @@ def insert_bulk(pd_table, conn, keys, data_iter):
     the relevant code in `pandas.io.sql`.
 
     [1] https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_sql.html
-    [2] https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
+    [2] https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations
     [3] https://github.com/pandas-dev/pandas/blob/v2.0.1/pandas/io/sql.py#L1011-L1027
     """
 


### PR DESCRIPTION
## About
Enable project to be slotted into the documentation tree.

## Details
The documentation will be published to https://cratedb.com/docs/sqlalchemy-cratedb/.
